### PR TITLE
fix: prevent rerender of ListHeaderComponent

### DIFF
--- a/src/ScrollView/index.tsx
+++ b/src/ScrollView/index.tsx
@@ -10,7 +10,7 @@ const ScrollViewComponent: Props = (props) => {
       keyExtractor={(_e, i) => 'dom' + i.toString()}
       ListEmptyComponent={null}
       renderItem={null}
-      ListHeaderComponent={() => <>{props.children}</>}
+      ListHeaderComponent={<>{props.children}</>}
     />
   );
 };


### PR DESCRIPTION
Instead of creating an anonymous function for the ListHeaderComponent prop (which is a new component on every render, causing it to get unmounted and remounted on every render) render the children as an Element.

According to the [documentation of RN FlatList](https://reactnative.dev/docs/flatlist#listheadercomponent), the ListHeaderComponent can be a function OR an Element. Changing this to element stops the rerenders.